### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ We are looking to develop a project metadata standard for DCgov (and beyond) bas
 Existing standards:
 
 * [BetaNYC civic.json](https://github.com/BetaNYC/civic.json)
-* [Code for DC civic.json](http://codefordc.org/resources/specification.html)
+* [Code for DC civic.json](http://open.dc.gov/civic.json/)
 * [Code for America API](http://codeforamerica.org/api/#project-properties)
 * [18F .about.yml](https://github.com/18F/about_yml)
 * [npm package.json](https://docs.npmjs.com/files/package.json)


### PR DESCRIPTION
Resolves #8
## Change:

Switched README link from a [defunct Code for DC page](http://codefordc.org/resources/specification.html) to an [open.dc.gov page](http://open.dc.gov/civic.json/)
## Decisions:

I chose the open.dc.gov `civic.json` homepage over the Code for DC
repository or the `civic.json` specifications page (like the original
link). Here is the rationale:
- The Code for DC site links to the open.dc.gov resources, and
  [their repository](https://github.com/codefordc/civic.json) appears to be stale; the open.dc.gov page appears to
  be their primary `civic.json` resource (see their [resources page](http://codefordc.org/resources/)).
- While the original link included `/specification` in its path, I
  think that the main `civic.json` page gives a better summary of the
  project, and the specification page (along with the builder and the
  validator) are easy to find.
